### PR TITLE
Update Page_General.h

### DIFF
--- a/BVB_WebConfig_OTA_V7/Page_General.h
+++ b/BVB_WebConfig_OTA_V7/Page_General.h
@@ -5,7 +5,7 @@
 const char PAGE_AdminGeneralSettings[] PROGMEM =  R"=====(
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<a href="/"  class="btn btn--s"><</a>&nbsp;&nbsp;<strong>General Settings</strong>
+<a href="/"  class="btn btn--s">&lt;</a>&nbsp;&nbsp;<strong>General Settings</strong>
 <hr>
 <form action="" method="post">
 <table border="0"  cellspacing="0" cellpadding="3" >


### PR DESCRIPTION
If you use the less than (<) or greater than (>) signs in your text, the browser might mix them with tags. Therefor use &lt; and &gt; instead.
