### PR TITLE
Update BVB_WebConfig_OTA_V7.ino

### DIFF
--- a/BVB_WebConfig_OTA_V7/BVB_WebConfig_OTA_V7.ino
+++ b/BVB_WebConfig_OTA_V7/BVB_WebConfig_OTA_V7.ino
@@ -32,7 +32,7 @@
 #include <Ticker.h>
 #include <EEPROM.h>
 #include <WiFiUdp.h>
-#include <credentials.h>
+//#include <credentials.h>
 
 #include "helpers.h"
 #include "global.h"
@@ -45,12 +45,20 @@
 #include "Page_Admin.h"
 #include "Page_Script.js.h"
 #include "Page_Style.css.h"
-#include "Page_NTPsettings.h"
+#include "Page_NTPSettings.h"
 #include "Page_Information.h"
 #include "Page_General.h"
 #include "Page_applSettings.h"
-#include "PAGE_NetworkConfiguration.h"
+#include "Page_NetworkConfiguration.h"
 #include "example.h"
+
+#ifndef ASP_SSID
+#define ASP_SSID "ESP8266"
+#endif
+
+#ifndef ASP_password
+#define ASP_password "secret"
+#endif
 
 extern "C" {
 #include "user_interface.h"


### PR DESCRIPTION
The includes are case sensitive on Linux and OS X systems, so fixed that. 
The other thing is that the <credentials.h> file is not available in the repository. I am guessing that they ought to contain default values for ASP_SSID and ASP_password. So getting rid of this one means a later compile error on ASP_SSID and ASP_password. Fixed that by defaulting to defaults if they are not defined.
